### PR TITLE
Make pack/avg current signed; remove charger command frames

### DIFF
--- a/lib/battery/messages.h
+++ b/lib/battery/messages.h
@@ -12,10 +12,12 @@
  **/ 
 struct Message1{
     uint64_t packVoltage: 16;
-    uint64_t packCurrent: 16;
+    int64_t packCurrent: 16; // driving->positive, charging->negative
     uint64_t packAmpHours: 16;
     uint64_t reserved: 16;
 };
+
+static_assert(sizeof(Message1) == 8, "Message1 size is not 8 bytes");
 
 /**
  * ID: 0x002
@@ -77,10 +79,11 @@ struct Message5 {
 struct Message6 {
     uint64_t packDCL : 8;
     uint64_t packCCL : 8;
-    uint64_t packCurrent : 16;
-    uint64_t avgCurrent : 16;
+    int64_t packCurrent : 16;  // driving->positive, charging->negative
+    int64_t avgCurrent : 16;   // driving->positive, charging->negative
     uint64_t reserved : 16;
 };
+static_assert(sizeof(Message6) == 8, "Message6 size is not 8 bytes");
 
 /**
  * ID: 0x202
@@ -121,53 +124,20 @@ struct Message355 {
 };
 
 /**
- * ID: 0x1806E7F4
- * @name Maximum Pack Voltage + Custom Flag
- * @param maxPackVoltage: Maximum pack voltage in mV
- * @param customFlag: User defined flag
- */
-struct Message1806E7F4 {
-    uint64_t maxPackVoltage : 16;
-    uint64_t customFlag : 8;
-    uint64_t reserved : 40;
-};
-
-// TODO: This message is sepcific for something but is also a copy of 1806E7F4.
-// TODO: This message details needs to be modified if these two messages are for specific cell sets
-/**
- * ID: 0x1806E5F4
- * @name Maximum Cell Voltage + Custom Flag
- * @param maxCellVoltage: Maximum cell voltage in mV
- * @param customFlag: User defined flag
- */
-struct Message1806E5F4 {
-    uint64_t maxCellVoltage : 16;
-    uint64_t customFlag : 8;
-    uint64_t reserved : 40;
-};
-
-// TODO: Look up the specific details of this message and modify the struct accordingly. 
-// TODO: This is currently a copy of 1806E7F4, but it may have different parameters if it's for specific cell sets.
-/**
- * ID: 0x1806E9F4
- * @name Maximum Cell Voltage + Custom Flag
- * @param maxCellVoltage: Maximum cell voltage in mV
- * @param customFlag: User defined flag
- */
-struct Message1806E9F4 {
-    uint64_t maxCellVoltage : 16;
-    uint64_t customFlag : 8;
-    uint64_t reserved : 40;
-};
-
-/**
  * ID: 0x18FF50E5
- * @name Blank Message
- * @note Used for logging presence on the bus.
+ * @name Charger Output Status
+ * @param outputVoltage: Charger output voltage (0.1 V per count)
+ * @param outputCurrent: Charger output current (0.1 A per count)
+ * @param statusFlags: Charger status bitmask (fault/over-temperature/etc.)
+ * @note big-endian charger-protocol frame, recall this message is big-endian on the wire, unlike the BMS frames
  */
 struct Message18FF50E5 {
-    // No data parameters defined
-    uint64_t reserved : 64;
+    uint64_t outputVoltage : 16;
+    uint64_t outputCurrent : 16;
+    uint64_t statusFlags : 8;
+    uint64_t reserved : 24;
 };
+
+static_assert(sizeof(Message18FF50E5) == 8, "Message18FF50E5 size is not 8 bytes");
 
 #endif // BATTERY_MESSAGES_H

--- a/test/test_battery/test_battery_messages.cpp
+++ b/test/test_battery/test_battery_messages.cpp
@@ -171,74 +171,23 @@ void test_encode_decode_message_355() {
     TEST_ASSERT_EQUAL(0x123456789ABC, message_out->reserved);
 }
 
-void test_encode_decode_message_1806E7F4() {
-    Message1806E7F4 message_in = { 0xAABB, 0xCC, 0x123456789A };
-    Frame frame(0x1806E7F4, &message_in);
+void run_encode_decode_message_18FF50E5() {
+    Message18FF50E5 message_in = { 0xAABB, 0xCCDD, 0xEE, 0x112233 };
+    Frame frame(0x18FF50E5, &message_in);
     TEST_ASSERT_EQUAL(0xBB, frame.data[0]);
     TEST_ASSERT_EQUAL(0xAA, frame.data[1]);
-    TEST_ASSERT_EQUAL(0xCC, frame.data[2]);
-    TEST_ASSERT_EQUAL(0x9A, frame.data[3]);
-    TEST_ASSERT_EQUAL(0x78, frame.data[4]);
-    TEST_ASSERT_EQUAL(0x56, frame.data[5]);
-    TEST_ASSERT_EQUAL(0x34, frame.data[6]);
-    TEST_ASSERT_EQUAL(0x12, frame.data[7]);
-
-    auto message_out = frame.decode<Message1806E7F4>();
-    TEST_ASSERT_EQUAL(0xAABB, message_out->maxPackVoltage);
-    TEST_ASSERT_EQUAL(0xCC, message_out->customFlag);
-    TEST_ASSERT_EQUAL(0x123456789A, message_out->reserved);
-}
-
-void test_encode_decode_message_1806E5F4() {
-    Message1806E5F4 message_in = { 0xBEEF, 0xDD, 0x1122334455 };
-    Frame frame(0x1806E5F4, &message_in);
-    TEST_ASSERT_EQUAL(0xEF, frame.data[0]);
-    TEST_ASSERT_EQUAL(0xBE, frame.data[1]);
     TEST_ASSERT_EQUAL(0xDD, frame.data[2]);
-    TEST_ASSERT_EQUAL(0x55, frame.data[3]);
-    TEST_ASSERT_EQUAL(0x44, frame.data[4]);
-    TEST_ASSERT_EQUAL(0x33, frame.data[5]);
-    TEST_ASSERT_EQUAL(0x22, frame.data[6]);
-    TEST_ASSERT_EQUAL(0x11, frame.data[7]);
-
-    auto message_out = frame.decode<Message1806E5F4>();
-    TEST_ASSERT_EQUAL(0xBEEF, message_out->maxCellVoltage);
-    TEST_ASSERT_EQUAL(0xDD, message_out->customFlag);
-    TEST_ASSERT_EQUAL(0x1122334455, message_out->reserved);
-}
-
-void test_encode_decode_message_1806E9F4() {
-    Message1806E9F4 message_in = { 0xCAFE, 0xEE, 0xAABBCCDDEE };
-    Frame frame(0x1806E9F4, &message_in);
-    TEST_ASSERT_EQUAL(0xFE, frame.data[0]);
-    TEST_ASSERT_EQUAL(0xCA, frame.data[1]);
-    TEST_ASSERT_EQUAL(0xEE, frame.data[2]);
-    TEST_ASSERT_EQUAL(0xEE, frame.data[3]);
-    TEST_ASSERT_EQUAL(0xDD, frame.data[4]);
-    TEST_ASSERT_EQUAL(0xCC, frame.data[5]);
-    TEST_ASSERT_EQUAL(0xBB, frame.data[6]);
-    TEST_ASSERT_EQUAL(0xAA, frame.data[7]);
-
-    auto message_out = frame.decode<Message1806E9F4>();
-    TEST_ASSERT_EQUAL(0xCAFE, message_out->maxCellVoltage);
-    TEST_ASSERT_EQUAL(0xEE, message_out->customFlag);
-    TEST_ASSERT_EQUAL(0xAABBCCDDEE, message_out->reserved);
-}
-
-void run_encode_decode_message_18FF50E5() {
-    Message18FF50E5 message_in = { 0x1122334455667788 };
-    Frame frame(0x18FF50E5, &message_in);
-    TEST_ASSERT_EQUAL(0x88, frame.data[0]);
-    TEST_ASSERT_EQUAL(0x77, frame.data[1]);
-    TEST_ASSERT_EQUAL(0x66, frame.data[2]);
-    TEST_ASSERT_EQUAL(0x55, frame.data[3]);
-    TEST_ASSERT_EQUAL(0x44, frame.data[4]);
+    TEST_ASSERT_EQUAL(0xCC, frame.data[3]);
+    TEST_ASSERT_EQUAL(0xEE, frame.data[4]);
     TEST_ASSERT_EQUAL(0x33, frame.data[5]);
     TEST_ASSERT_EQUAL(0x22, frame.data[6]);
     TEST_ASSERT_EQUAL(0x11, frame.data[7]);
 
     auto message_out = frame.decode<Message18FF50E5>();
-    TEST_ASSERT_EQUAL(0x1122334455667788, message_out->reserved);
+    TEST_ASSERT_EQUAL(0xAABB, message_out->outputVoltage);
+    TEST_ASSERT_EQUAL(0xCCDD, message_out->outputCurrent);
+    TEST_ASSERT_EQUAL(0xEE, message_out->statusFlags);
+    TEST_ASSERT_EQUAL(0x112233, message_out->reserved);
 }
 
 void run_message_tests() {
@@ -251,8 +200,5 @@ void run_message_tests() {
     RUN_TEST(test_encode_decode_message_202);
     RUN_TEST(test_encode_decode_message_351);
     RUN_TEST(test_encode_decode_message_355);
-    RUN_TEST(test_encode_decode_message_1806E7F4);
-    RUN_TEST(test_encode_decode_message_1806E5F4);
-    RUN_TEST(test_encode_decode_message_1806E9F4);
     RUN_TEST(run_encode_decode_message_18FF50E5);
 }


### PR DESCRIPTION
Deleted charger command structs 1806E5F4/E7F4/E9F4; rewrote 18FF50E5 as read-only status; updated tests.
